### PR TITLE
Update OC_Util.php fix #39960

### DIFF
--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -629,7 +629,9 @@ class OC_Util {
 				'openssl_verify' => 'OpenSSL',
 			],
 			'defined' => [
-				'PDO::ATTR_DRIVER_NAME' => 'PDO'
+				'PDO::ATTR_DRIVER_NAME' => 'PDO',
+				'PASSWORD_ARGON2I' => 'PASSWORD_ARGON2I',
+				'PASSWORD_ARGON2ID' => 'PASSWORD_ARGON2ID'
 			],
 			'ini' => [
 				'default_charset' => 'UTF-8',


### PR DESCRIPTION
Added PASSWORD_ARGON2I and PASSWORD_ARGON2ID to defined in OC_Util.checkServer


* Resolves: #39960

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
@kesselb